### PR TITLE
No need to use apt-get for the openjdk-8-jre image

### DIFF
--- a/openjdk-8-jre/Dockerfile
+++ b/openjdk-8-jre/Dockerfile
@@ -1,12 +1,8 @@
 FROM openjdk:8-jre
 MAINTAINER DevOps <devops@newmotion.com>
 
-RUN apt-get update && \
-    apt-get -y install curl unzip && \
-    curl -fsSL https://www.yourkit.com/download/docker/YourKit-JavaProfiler-2018.04-docker.zip > /tmp/yjp.zip && \
+RUN curl -fsSL https://www.yourkit.com/download/docker/YourKit-JavaProfiler-2018.04-docker.zip > /tmp/yjp.zip && \
     unzip -o -d /usr/local /tmp/yjp.zip  && \
-    apt-get -y remove curl unzip && \
-    apt-get autoclean && \
     rm /tmp/yjp.zip && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/
 


### PR DESCRIPTION
curl and unzip are already installed in openjdk:8-jre so no need to install them.  Whats more, it was then removing them, meaning they were no longer available when they are available by default in openjdk:8-jre